### PR TITLE
Fix broken image link, add fenced block format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ If you want to add a canned response, or revise one that's already present, plea
 
 * Files should follow this format:
 
-```
+```text
 # Response Category (e.g. `#beginners` Tag Adjustments)
 
 ## Response Purpose

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Canned moderation responses for the [DEV Community](https://dev.to/).
 
-<img src=https://github.com/CodeMouse92/DEVModInACan/blob/master/modinacan-logo.svg width=300vw>
+<img src=./modinacan-logo.svg width=300vw>
 
 ## Purpose
 


### PR DESCRIPTION
Two small updates to improve the existing repo docs.

- remove renamed / non-existent branch name from image reference
- added fenced block type to `CONTRIBUTING.md` so that it renders more reliably in different previews.